### PR TITLE
Fix: prevent forbidden characters in captcha id and double use of captcha

### DIFF
--- a/src/AbstractWord.php
+++ b/src/AbstractWord.php
@@ -394,7 +394,7 @@ abstract class AbstractWord extends AbstractAdapter
         $input = strtolower($value['input']);
         $this->setValue($input);
 
-        if (! isset($value['id'])) {
+        if (!preg_match('/^[a-f0-9][a-f0-9_\\\\]+$/i', $value['id'])) {
             $this->error(self::MISSING_ID);
             return false;
         }
@@ -404,7 +404,9 @@ abstract class AbstractWord extends AbstractAdapter
             $this->error(self::BAD_CAPTCHA);
             return false;
         }
-
+        //Invalidate the captcha after successful use
+        $this->generate();
+        
         return true;
     }
 

--- a/src/AbstractWord.php
+++ b/src/AbstractWord.php
@@ -10,6 +10,7 @@ use function class_exists;
 use function count;
 use function is_array;
 use function md5;
+use function preg_match;
 use function random_bytes;
 use function random_int;
 use function strlen;
@@ -394,7 +395,7 @@ abstract class AbstractWord extends AbstractAdapter
         $input = strtolower($value['input']);
         $this->setValue($input);
 
-        if (!isset($value['id']) || ! preg_match('/^[a-f0-9][a-f0-9_\\\\]+$/i', (string) $value['id'])) {
+        if (! isset($value['id']) || ! preg_match('/^[a-f0-9][a-f0-9_\\\\]+$/i', (string) $value['id'])) {
             $this->error(self::MISSING_ID);
             return false;
         }
@@ -406,7 +407,7 @@ abstract class AbstractWord extends AbstractAdapter
         }
         //Invalidate the captcha after successful use
         $this->generate();
-        
+
         return true;
     }
 

--- a/src/AbstractWord.php
+++ b/src/AbstractWord.php
@@ -15,6 +15,7 @@ use function random_int;
 use function strlen;
 use function strtolower;
 use function substr;
+use function preg_match;
 
 /**
  * AbstractWord-based captcha adapter
@@ -394,7 +395,7 @@ abstract class AbstractWord extends AbstractAdapter
         $input = strtolower($value['input']);
         $this->setValue($input);
 
-        if (!isset($value['id']) || ! preg_match('/^[a-f0-9][a-f0-9_\\\\]+$/i', (string) $value['id'])) {
+        if (! isset($value['id']) || ! preg_match('/^[a-f0-9][a-f0-9_\\\\]+$/i', (string) $value['id'])) {
             $this->error(self::MISSING_ID);
             return false;
         }
@@ -406,7 +407,7 @@ abstract class AbstractWord extends AbstractAdapter
         }
         //Invalidate the captcha after successful use
         $this->generate();
-        
+
         return true;
     }
 

--- a/src/AbstractWord.php
+++ b/src/AbstractWord.php
@@ -16,7 +16,6 @@ use function random_int;
 use function strlen;
 use function strtolower;
 use function substr;
-use function preg_match;
 
 /**
  * AbstractWord-based captcha adapter

--- a/src/AbstractWord.php
+++ b/src/AbstractWord.php
@@ -394,7 +394,7 @@ abstract class AbstractWord extends AbstractAdapter
         $input = strtolower($value['input']);
         $this->setValue($input);
 
-        if (!preg_match('/^[a-f0-9][a-f0-9_\\\\]+$/i', $value['id'])) {
+        if (!isset($value['id']) || ! preg_match('/^[a-f0-9][a-f0-9_\\\\]+$/i', (string) $value['id'])) {
             $this->error(self::MISSING_ID);
             return false;
         }

--- a/src/AbstractWord.php
+++ b/src/AbstractWord.php
@@ -405,8 +405,8 @@ abstract class AbstractWord extends AbstractAdapter
             $this->error(self::BAD_CAPTCHA);
             return false;
         }
-        //Invalidate the captcha after successful use
-        $this->generate();
+        //Invalidate the captcha by generating a new word after successful use
+        $this->setWord($this->generateWord());
 
         return true;
     }

--- a/test/ImageTest.php
+++ b/test/ImageTest.php
@@ -239,9 +239,9 @@ class ImageTest extends TestCase
     {
         $this->captcha->generate();
         $id    = $this->captcha->getId();
-        $input = ["id" => \substr($id, 0, strlen($id) - 1) . "+", "input" => $this->captcha->getWord()];
+        $input = ["id" => substr($id, 0, strlen($id) - 1) . "+", "input" => $this->captcha->getWord()];
         $this->assertFalse($this->captcha->isValid($input));
-        $input = ["id" => \substr($id, 0, strlen($id) - 1) . "-", "input" => $this->captcha->getWord()];
+        $input = ["id" => substr($id, 0, strlen($id) - 1) . "-", "input" => $this->captcha->getWord()];
         $this->assertFalse($this->captcha->isValid($input));
     }
 

--- a/test/ImageTest.php
+++ b/test/ImageTest.php
@@ -21,6 +21,7 @@ use function is_dir;
 use function mkdir;
 use function sleep;
 use function strlen;
+use function substr;
 use function sys_get_temp_dir;
 use function unlink;
 
@@ -237,7 +238,7 @@ class ImageTest extends TestCase
     public function testInvalidIDCharactersSubmittedNotValidates(): void
     {
         $this->captcha->generate();
-        $id = $this->captcha->getId();
+        $id    = $this->captcha->getId();
         $input = ["id" => \substr($id, 0, strlen($id) - 1) . "+", "input" => $this->captcha->getWord()];
         $this->assertFalse($this->captcha->isValid($input));
         $input = ["id" => \substr($id, 0, strlen($id) - 1) . "-", "input" => $this->captcha->getWord()];

--- a/test/ImageTest.php
+++ b/test/ImageTest.php
@@ -226,6 +226,24 @@ class ImageTest extends TestCase
         $this->assertFalse($this->captcha->isValid($input));
     }
 
+    public function testDoubleSubmitNotValidates(): void
+    {
+        $this->captcha->generate();
+        $input = ["id" => $this->captcha->getId(), "input" => $this->captcha->getWord()];
+        $this->assertTrue($this->captcha->isValid($input));
+        $this->assertFalse($this->captcha->isValid($input));
+    }
+
+    public function testInvalidIDCharactersSubmittedNotValidates(): void
+    {
+        $this->captcha->generate();
+        $id = $this->captcha->getId();
+        $input = ["id" => \substr($id, 0, strlen($id) - 1) . "+", "input" => $this->captcha->getWord()];
+        $this->assertFalse($this->captcha->isValid($input));
+        $input = ["id" => \substr($id, 0, strlen($id) - 1) . "-", "input" => $this->captcha->getWord()];
+        $this->assertFalse($this->captcha->isValid($input));
+    }
+
     public function testWrongWordNotValid(): void
     {
         $this->captcha->generate();


### PR DESCRIPTION
Solves this bug:
Closes https://github.com/laminas/laminas-captcha/issues/13
and another one where attackers could just resend the last captcha over and over again, until the expiration period has passed.
Thats not what i would expect a captcha class to allow

BREAKING CHANGE:
prevents double sending of captchas - invalidates them after successful validation by regeneration of words