### PR TITLE
Deprecate Figlet captcha adapter

### DIFF
--- a/docs/book/adapters.md
+++ b/docs/book/adapters.md
@@ -87,6 +87,10 @@ CAPTCHA solution and should only be used for testing. It extends
 
 ## Laminas\\Captcha\\Figlet
 
+CAUTION: **Deprecated**
+This adapter is deprecated and will be removed in version 3.0.0.
+Please use the `Laminas\Captcha\Image` adapter instead or one of the other available adapters.
+
 The `Laminas\Captcha\Figlet` adapter utilizes `Laminas\Text\Figlet` to present a
 figlet to the user.
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
+<files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
   <file src="src/AbstractAdapter.php">
     <DocblockTypeContradiction>
       <code><![CDATA[! is_array($options) && ! $options instanceof Traversable]]></code>
@@ -46,6 +46,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Factory.php">
+    <DeprecatedClass>
+      <code><![CDATA[Figlet::class]]></code>
+    </DeprecatedClass>
     <DocblockTypeContradiction>
       <code><![CDATA[is_array($options)]]></code>
     </DocblockTypeContradiction>
@@ -212,6 +215,11 @@
     </UndefinedThisPropertyFetch>
   </file>
   <file src="test/FactoryTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[Figlet::class]]></code>
+      <code><![CDATA[Figlet::class]]></code>
+      <code><![CDATA[Figlet::class]]></code>
+    </DeprecatedClass>
     <DocblockTypeContradiction>
       <code><![CDATA[null === $this->tmpDir]]></code>
     </DocblockTypeContradiction>
@@ -231,6 +239,14 @@
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="test/FigletTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[FigletCaptcha]]></code>
+      <code><![CDATA[FigletCaptcha::class]]></code>
+      <code><![CDATA[new FigletCaptcha($config)]]></code>
+      <code><![CDATA[new FigletCaptcha([
+            'sessionClass' => \LaminasTest\Captcha\TestAsset\SessionContainer::class,
+        ])]]></code>
+    </DeprecatedClass>
     <MixedMethodCall>
       <code><![CDATA[setTimeout]]></code>
       <code><![CDATA[setTimeout]]></code>

--- a/src/Figlet.php
+++ b/src/Figlet.php
@@ -12,6 +12,8 @@ use Override;
  *
  * Note that this engine seems not to like numbers
  *
+ * @deprecated This adapter is deprecated and will be removed in version 3.0.0.
+ *             Please use the `Laminas\Captcha\Image` adapter instead or one of the other available adapters.
  * @final This class should not be extended
  */
 class Figlet extends AbstractWord

--- a/src/Figlet.php
+++ b/src/Figlet.php
@@ -14,6 +14,7 @@ use Override;
  *
  * @deprecated This adapter is deprecated and will be removed in version 3.0.0.
  *             Please use the `Laminas\Captcha\Image` adapter instead or one of the other available adapters.
+ *
  * @final This class should not be extended
  */
 class Figlet extends AbstractWord


### PR DESCRIPTION
Mark the `Laminas\Captcha\Figlet` adapter as deprecated in both documentation and code. Notify users about its removal in version 3.0.0 and recommend using the `Laminas\Captcha\Image` adapter or alternatives.


